### PR TITLE
Precision format

### DIFF
--- a/examples/large_int_use.rs
+++ b/examples/large_int_use.rs
@@ -12,14 +12,20 @@ fn main() {
     // on integers greater than u128::MAX
     let big_num = LargeInt::from(u128::MAX);
     let bigger_num: LargeInt = big_num.clone() + 1;
-    println!("{} > u128::MAX (={})!", bigger_num.to_string(), u128::MAX.to_string());
+    println!("{} > u128::MAX (={})!", bigger_num, u128::MAX);
     assert!(bigger_num > big_num);
 
     println!();
     let huge_num = big_num * u128::MAX;
     println!("Check out this number...");
-    println!("{}\nWow, that's definitely over 9000!", huge_num.to_string());
-    println!("Takes a while to print though... Better use primitives unless you need something bigger!");
+    println!("{}\nWow, that's definitely over 9000!", huge_num);
+    println!("Takes a while to print though...");
+
+    // printing in scientific notation will be faster because there
+    // are less digits to calculate. format like floats, where the
+    // precision is the number of decmial places
+    println!("So you can use scientific notation as well!");
+    println!("{:.3}", huge_num);
 
     // integers that are unbounded in both positive and negative
     println!("");

--- a/tests/test_large_int.rs
+++ b/tests/test_large_int.rs
@@ -7,12 +7,18 @@ use large_int::large_int::LargeInt;
 #[test]
 fn test_string_conversions() {
     let rep = "777777777777777777777777777777777777777777777777770";
+    let to_2 = "7.77e50";
     let int = LargeInt::from_str(rep).unwrap();
     assert_eq!(int.to_string(), rep);
+    assert_eq!(format!("{:.2}", int.to_string()), to_2);
 
     let rep = "100000000000000000000000000000000000000";
     let int = LargeInt::from_str(rep).unwrap();
     assert_eq!(int, LargeInt::from(100000000000000000000000000000000000000u128));
+
+    let int = LargeInt::from(541);
+    assert_eq!(int.to_string(), "541");
+    assert_eq!(format!("{:.1}", int.to_string()), "5.4e2");
 }
 
 #[test]

--- a/tests/test_large_int.rs
+++ b/tests/test_large_int.rs
@@ -10,7 +10,7 @@ fn test_string_conversions() {
     let to_2 = "7.77e50";
     let int = LargeInt::from_str(rep).unwrap();
     assert_eq!(int.to_string(), rep);
-    assert_eq!(format!("{:.2}", int.to_string()), to_2);
+    assert_eq!(format!("{:.2}", int), to_2);
 
     let rep = "100000000000000000000000000000000000000";
     let int = LargeInt::from_str(rep).unwrap();
@@ -18,7 +18,18 @@ fn test_string_conversions() {
 
     let int = LargeInt::from(541);
     assert_eq!(int.to_string(), "541");
-    assert_eq!(format!("{:.1}", int.to_string()), "5.4e2");
+    assert_eq!(format!("{:.1}", int), "5.4e2");
+    assert_eq!(format!("{:.5}", int), "5.41000e2");
+
+    let int = LargeInt::from(-3451);
+    assert_eq!(format!("{}", int), "-3451");
+    assert_eq!(format!("{:.1}", int), "-3.4e3");
+    assert_eq!(format!("{:.9}", int), "-3.451000000e3");
+
+    let int = LargeInt::from(0);
+    assert_eq!(format!("{:.4}", int), "0.0000e0");
+    let int = LargeInt::from(-1);
+    assert_eq!(format!("{:.2}", int), "-1.00e0");
 }
 
 #[test]


### PR DESCRIPTION
Add the ability to format printing LargeInt such that they appear in scientific notation (faster to print this way).